### PR TITLE
Resize does not work properly, if width/height attribute are not set on the image tag

### DIFF
--- a/jquery.row-grid.js
+++ b/jquery.row-grid.js
@@ -37,7 +37,7 @@
     // read
     var containerWidth = container.clientWidth-parseFloat($(container).css('padding-left'))-parseFloat($(container).css('padding-right'));
     var itemAttrs = [];
-    var theImage;
+    var theImage, w, h;
     for(var i = 0; i < itemsSize; ++i) {
       theImage = items[i].getElementsByTagName('img')[0];
       if (!theImage) {
@@ -47,9 +47,16 @@
         continue;
       }
       // get width and height via attribute or js value
+      if (!(w = parseInt(theImage.getAttribute('width')))) {
+        theImage.setAttribute('width', w = theImage.offsetWidth);
+      } 
+      if (!(h = parseInt(theImage.getAttribute('height')))) {
+        theImage.setAttribute('height', h = theImage.offsetHeight);
+      } 
+      
       itemAttrs[i] = {
-        width: parseInt(theImage.getAttribute('width')) || theImage.offsetWidth,
-        height: parseInt(theImage.getAttribute('height')) || theImage.offsetHeight
+        width: w,
+        height: h
       };
     }
     itemsSize = items.length;


### PR DESCRIPTION
Currently resizing does not work properly, if the image tag does not have a width and/or height attribute: up-scaling doesn't work at all (if it was downscaled before), because the script has no information about the original width/height of the image and downscaling does not work properly, if you specified only one of the attributes (height / width). 

My pull-request proposes a fix for this: the attributes width/height are set with the value from offsetWidth/offsetHeight, only if the attributes are not already available. so the attributes get set only for (new) images, that have not already a width/height attribute set.

Nevertheless: great work, your rowGrid.js!
